### PR TITLE
Remove gunzip of vectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN pip install -r /src/requirements.txt
 RUN mkdir /home/ubuntu
 WORKDIR /home/ubuntu
 
-RUN wget https://s3.amazonaws.com/mordecai-geo/GoogleNews-vectors-negative300.bin.gz; \
-gunzip GoogleNews-vectors-negative300.bin.gz
+RUN wget https://s3.amazonaws.com/mordecai-geo/GoogleNews-vectors-negative300.bin.gz
 
 RUN git clone https://github.com/mit-nlp/MITIE.git
 WORKDIR /home/ubuntu/MITIE

--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,7 @@
 [Locations]
 mitie_directory = /home/ubuntu/MITIE/mitielib
 mitie_ner_model = /home/ubuntu/MITIE/MITIE-models/english/ner_model.dat
-word2vec_model = /home/ubuntu/GoogleNews-vectors-negative300.bin
+word2vec_model = /home/ubuntu/GoogleNews-vectors-negative300.bin.gz
 
 #[Server]
 #geonames = 54.152.85.116


### PR DESCRIPTION
There's no need to gunzip the Google vectors, gensim can load them up just fine.